### PR TITLE
Add Podzol as a valid ground type

### DIFF
--- a/src/main/java/de/jeff_media/LumberJack/TreeUtils.java
+++ b/src/main/java/de/jeff_media/LumberJack/TreeUtils.java
@@ -33,7 +33,8 @@ public class TreeUtils {
                         Material.DIRT,
                         Material.GRASS_BLOCK,
                         Material.MYCELIUM,
-                        Material.COARSE_DIRT};
+                        Material.COARSE_DIRT,
+                        Material.PODZOL};
         }
         switch(mat.name()) {
             case "CRIMSON_STEM":


### PR DESCRIPTION
Hey mfnalex, i really like your plugin. On my server the people had problems if trees grow on Podzol, in the version 2.2 i could add it to the `tree-ground-blocks` property. 
The minecraft wiki says you can place saplings on Podzol and that trees could grow on them.
https://minecraft.gamepedia.com/Podzol#Info

Thx for your work :)